### PR TITLE
Improve worker pool chart templating

### DIFF
--- a/spacelift-workerpool-controller/templates/_helpers.tpl
+++ b/spacelift-workerpool-controller/templates/_helpers.tpl
@@ -51,12 +51,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Default controller manager service account name
+*/}}
+{{- define "spacelift-workerpool-controller.defaultServiceAccountName" -}}
+{{- printf "%s-controller-manager" (include "spacelift-workerpool-controller.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "spacelift-workerpool-controller.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "spacelift-workerpool-controller.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.controllerManager.serviceAccount.create }}
+{{- default (include "spacelift-workerpool-controller.defaultServiceAccountName" .) .Values.controllerManager.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.controllerManager.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/spacelift-workerpool-controller/templates/_helpers.tpl
+++ b/spacelift-workerpool-controller/templates/_helpers.tpl
@@ -61,9 +61,5 @@ Default controller manager service account name
 Create the name of the service account to use
 */}}
 {{- define "spacelift-workerpool-controller.serviceAccountName" -}}
-{{- if .Values.controllerManager.serviceAccount.create }}
 {{- default (include "spacelift-workerpool-controller.defaultServiceAccountName" .) .Values.controllerManager.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.controllerManager.serviceAccount.name }}
-{{- end }}
 {{- end }}

--- a/spacelift-workerpool-controller/templates/deployment.yaml
+++ b/spacelift-workerpool-controller/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: {{ include "spacelift-workerpool-controller.fullname" . }}-controller-manager
+      serviceAccountName: {{ include "spacelift-workerpool-controller.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.controllerManager.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/spacelift-workerpool-controller/templates/deployment.yaml
+++ b/spacelift-workerpool-controller/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
           }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
+        {{- with .Values.controllerManager.manager.extraVolumeMounts }}
+        volumeMounts:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -93,5 +97,9 @@ spec:
       {{- end }}
       {{- with .Values.controllerManager.tolerations }}
       tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.extraVolumes }}
+      volumes:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/spacelift-workerpool-controller/templates/deployment.yaml
+++ b/spacelift-workerpool-controller/templates/deployment.yaml
@@ -4,7 +4,14 @@ metadata:
   name: {{ include "spacelift-workerpool-controller.fullname" . }}-controller-manager
   labels:
     control-plane: controller-manager
-  {{- include "spacelift-workerpool-controller.labels" . | nindent 4 }}
+    {{- include "spacelift-workerpool-controller.labels" . | nindent 4 }}
+    {{- with .Values.controllerManager.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.controllerManager.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
   selector:
@@ -15,7 +22,10 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
-      {{- include "spacelift-workerpool-controller.selectorLabels" . | nindent 8 }}
+        {{- include "spacelift-workerpool-controller.selectorLabels" . | nindent 8 }}
+        {{- with .Values.controllerManager.manager.extraPodLabels }}
+        {{- toYaml . | nindent 8}}
+        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
         {{- with .Values.controllerManager.podAnnotations }}

--- a/spacelift-workerpool-controller/templates/leader-election-rbac.yaml
+++ b/spacelift-workerpool-controller/templates/leader-election-rbac.yaml
@@ -49,5 +49,5 @@ roleRef:
   name: '{{ include "spacelift-workerpool-controller.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "spacelift-workerpool-controller.fullname" . }}-controller-manager'
+  name: {{ include "spacelift-workerpool-controller.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'

--- a/spacelift-workerpool-controller/templates/manager-rbac.yaml
+++ b/spacelift-workerpool-controller/templates/manager-rbac.yaml
@@ -70,7 +70,7 @@ roleRef:
   name: '{{ include "spacelift-workerpool-controller.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "spacelift-workerpool-controller.fullname" . }}-controller-manager'
+  name: {{ include "spacelift-workerpool-controller.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'
 {{ else }}
 {{ range $index, $namespace := .Values.controllerManager.namespaces }}
@@ -98,7 +98,7 @@ roleRef:
   name: '{{ include "spacelift-workerpool-controller.fullname" $ }}-manager-role'
 subjects:
   - kind: ServiceAccount
-    name: '{{ include "spacelift-workerpool-controller.fullname" $ }}-controller-manager'
+    name: {{ include "spacelift-workerpool-controller.serviceAccountName" $ }}
     namespace: '{{ $.Release.Namespace }}'
 {{ end }}
 {{ end }}

--- a/spacelift-workerpool-controller/templates/metrics-rbac.yaml
+++ b/spacelift-workerpool-controller/templates/metrics-rbac.yaml
@@ -31,7 +31,7 @@ roleRef:
   name: '{{ include "spacelift-workerpool-controller.fullname" . }}-metrics-auth-role'
 subjects:
   - kind: ServiceAccount
-    name: '{{ include "spacelift-workerpool-controller.fullname" . }}-controller-manager'
+    name: {{ include "spacelift-workerpool-controller.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/spacelift-workerpool-controller/templates/serviceaccount.yaml
+++ b/spacelift-workerpool-controller/templates/serviceaccount.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.controllerManager.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "spacelift-workerpool-controller.fullname" . }}-controller-manager
+  name: {{ include "spacelift-workerpool-controller.serviceAccountName" . }}
   labels:
   {{- include "spacelift-workerpool-controller.labels" . | nindent 4 }}
   {{- with .Values.controllerManager.serviceAccount.labels }}
@@ -9,3 +10,4 @@ metadata:
   {{- end }}
   annotations:
     {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}
+{{- end }}

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -23,6 +23,7 @@ controllerManager:
       requests:
         cpu: 100m
         memory: 128Mi
+    extraVolumeMounts: []
   replicas: 1
   podAnnotations: {}
   serviceAccount:
@@ -34,6 +35,7 @@ controllerManager:
   nodeSelector: {}
   tolerations: []
   topologySpreadConstraints: []
+  extraVolumes: []
 kubernetesClusterDomain: cluster.local
 # The metric service will expose a metrics endpoint that can be scraped by a prometheus instance.
 # This is disabled by default, enable this if you want to enable controller observability.

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -24,7 +24,9 @@ controllerManager:
         cpu: 100m
         memory: 128Mi
     extraVolumeMounts: []
+    extraPodLabels: {}
   replicas: 1
+  annotations: {}
   podAnnotations: {}
   serviceAccount:
     create: true
@@ -35,6 +37,7 @@ controllerManager:
   nodeSelector: {}
   tolerations: []
   topologySpreadConstraints: []
+  extraLabels: {}
   extraVolumes: []
 kubernetesClusterDomain: cluster.local
 # The metric service will expose a metrics endpoint that can be scraped by a prometheus instance.

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -26,8 +26,11 @@ controllerManager:
   replicas: 1
   podAnnotations: {}
   serviceAccount:
+    create: true
     annotations: {}
     labels: {}
+    # If you are using a custom service account, you can specify it here.
+    # name:
   nodeSelector: {}
   tolerations: []
   topologySpreadConstraints: []


### PR DESCRIPTION
- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated

This PR adds a couple thing to the templating of the `spacelift-workerpool-controller` chart
- Allow using an existing service account instead of always creating one and to customise the name of the service account created  
  - **This is a no-op if the default values are not modified**. It keeps the previous behaviour as default, so this should not trigger a change in the service account name of current users of the chart.
- Allow adding extra labels to both the deployment and the pods
- Allow adding annotations to the controller manager deployment
- Allow adding volumes and volumeMounts to controller manager

Please let me know if this does not conform to some of your style agreements, or if you would prefer the service account changes in a separated PR.